### PR TITLE
Support strings, ints, and ObjectIds for _id

### DIFF
--- a/mongoadmin_project/mongoadmin/urls.py
+++ b/mongoadmin_project/mongoadmin/urls.py
@@ -10,6 +10,6 @@ urlpatterns = patterns('mongoadmin',
     url(r'^mongo/(?P<connection_name>[^/]+)/(?P<database_name>[^/]+)/$', views.DatabaseView.as_view()),
     url(r'^mongo/(?P<connection_name>[^/]+)/(?P<database_name>[^/]+)/(?P<collection_name>[^/]+)/$', views.CollectionView.as_view()),
     url(r'^mongo/(?P<connection_name>[^/]+)/(?P<database_name>[^/]+)/(?P<collection_name>[^/]+)/add/$', views.CreateDocumentView.as_view()),
-    url(r'^mongo/(?P<connection_name>[^/]+)/(?P<database_name>[^/]+)/(?P<collection_name>[^/]+)/(?P<pk>[a-z\d]+)/$', views.UpdateDocumentView.as_view()),
-    url(r'^mongo/(?P<connection_name>[^/]+)/(?P<database_name>[^/]+)/(?P<collection_name>[^/]+)/(?P<pk>[a-z\d]+)/delete/$', views.DeleteDocumentView.as_view()),
+    url(r'^mongo/(?P<connection_name>[^/]+)/(?P<database_name>[^/]+)/(?P<collection_name>[^/]+)/(?P<pk>[^/]+)/$', views.UpdateDocumentView.as_view()),
+    url(r'^mongo/(?P<connection_name>[^/]+)/(?P<database_name>[^/]+)/(?P<collection_name>[^/]+)/(?P<pk>[^/]+)/delete/$', views.DeleteDocumentView.as_view()),
 )


### PR DESCRIPTION
This is the first solution suggested in my bug report for issue #7. It makes things work when _id is an integer, string, or ObjectId, which is enough to let me use mongoadmin. It is broken when the _id is a string that happens to be an integer such as the string "12". It is also broken for more obscure types of _ids.
