### PR TITLE
FIXED: tag url shifts to new-style in Django1.5

### DIFF
--- a/mongoadmin_project/mongoadmin/templates/mongoadmin/base.html
+++ b/mongoadmin_project/mongoadmin/templates/mongoadmin/base.html
@@ -48,7 +48,7 @@
 {% endcomment %}
               <ul class="nav secondary-nav">
               {% if show_disconnect %}
-                <li><a href="{% url auth_logout %}">Disconnect</a></li>
+                <li><a href="{% url 'auth_logout' %}">Disconnect</a></li>
               {% endif %}
               </ul>
 {% comment %}


### PR DESCRIPTION
Tag {% url  ... %} style already shifted in Django 1.5.
Check this for more info. https://docs.djangoproject.com/en/1.5/releases/1.5/#overview
